### PR TITLE
Change instructions for forcing 1.7* JVM on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Intellij plugin I've written and is still a work in progress to get the full sup
 I personally use a 1.8 JDK but the majority of users should be on a 1.7 JDK so I have written this plugin at the 1.7 language level. It will not work with a 1.6 JDK because
 it uses features of 1.7. If you are an OSX user like me - then you will need to Run intellij using 1.7 or 1.8 to use this plugin by doing the following:
 
-To force running under JDK 1.7 edit /Applications/<Product>.app/Contents/Info.plist file, change JVMVersion from 1.6* to 1.7* :
+To force running under JDK 1.7 copy `/Applications/<Product>.app/Contents/bin/idea.properties` to `~/Library/Preferences/<Product>/` and
+change the JVMVersion key to 1.7*:
 
-```xml
-<key>JVMVersion</key>
-<string>1.7*</string>
+```
+JVMVersion=1.7*
 ```
 
 ## Progress


### PR DESCRIPTION
Modifying the Info.plist file will invalidate the application signature, which makes updating a pain. The proper method for forcing IntelliJ to run under a higher JDK is to copy the `idea.properties` to your user preferences instead ([see here for more info](http://stackoverflow.com/questions/13578062/how-to-increase-ide-memory-limit-in-intellij-idea-on-mac/13581526#13581526)).