### PR TITLE
Add an extra Kotlin dependency. Set KotlinTest version as Kotlin ver…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,8 @@ dependencies {
     compile project('jps-shared')
     compile project('jps-plugin')
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile 'io.kotlintest:kotlintest:1.3.3'
+    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    compile "io.kotlintest:kotlintest:$kotlintest_version"
 }
 
 apply plugin: 'idea'

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ version = 1.12
 ideaVersion = 2017.1
 javaVersion = 1.8
 kotlin_version = 1.1.0
+kotlintest_version = 1.3.3
 sources = true
 isEAP = false
 org.gradle.jvmargs=-XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -XX:+CMSPermGenSweepingEnabled -XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8


### PR DESCRIPTION
Also set KotlinTest version as Kotlin version is set.

cf. Issue #140.

All tests pass, and the message as shown Issue #140 has gone. Also the plugin loads into IDEA 2017.1.